### PR TITLE
LDEV-6191 fix query parser bugs, add type=explicit for native Lucene syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.0.0.166
+
+- [LDEV-6194](https://luceeserver.atlassian.net/browse/LDEV-6194) — fix NPE on `criteria="*"`, guard topN for empty results, escape special chars in Verity parser
+- [LDEV-6193](https://luceeserver.atlassian.net/browse/LDEV-6193) — `type="explicit"` enables native Lucene QueryParser syntax
+- [LDEV-2025](https://luceeserver.atlassian.net/browse/LDEV-2025) — fix special characters in search criteria
+- [LDEV-1745](https://luceeserver.atlassian.net/browse/LDEV-1745) — fix phrase queries with `+`/`-` modifiers, fix numHits error
+- Add test cases for [LDEV-1879](https://luceeserver.atlassian.net/browse/LDEV-1879), [LDEV-3310](https://luceeserver.atlassian.net/browse/LDEV-3310), [LDEV-2025](https://luceeserver.atlassian.net/browse/LDEV-2025), [LDEV-1166](https://luceeserver.atlassian.net/browse/LDEV-1166), [LDEV-1550](https://luceeserver.atlassian.net/browse/LDEV-1550), [LDEV-1023](https://luceeserver.atlassian.net/browse/LDEV-1023), [LDEV-2032](https://luceeserver.atlassian.net/browse/LDEV-2032)
+
 ## 3.0.0.165
 
 - [LDEV-6182](https://luceeserver.atlassian.net/browse/LDEV-6182) — fix Lucee 6.2 compatibility

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.lucee</groupId>
     <artifactId>lucene-search-extension</artifactId>
-    <version>3.0.0.165-SNAPSHOT</version>
+    <version>3.0.0.166-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Lucene Search Engine</name>
 

--- a/source/java/src/org/lucee/extension/search/lucene/LuceneSearchCollection.java
+++ b/source/java/src/org/lucee/extension/search/lucene/LuceneSearchCollection.java
@@ -34,6 +34,7 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.KnnFloatVectorQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
@@ -626,9 +627,6 @@ public final class LuceneSearchCollection extends SearchCollectionSupport {
 	public SearchResulItem[] _search(SearchData data, String criteria, String language, short type, final int startrow,
 			final int maxrow, String categoryTree, String[] category) throws SearchException {
 		try {
-			if (type != SEARCH_TYPE_SIMPLE)
-				throw new SearchException("search type explicit not supported");
-
 			Analyzer analyzer = SearchUtil.getAnalyzer(language);
 			Query query = null;
 			Op op = null;
@@ -663,15 +661,30 @@ public final class LuceneSearchCollection extends SearchCollectionSupport {
 			}
 
 			HTMLFormatterWithScore formatter = null;
-			if (!criteria.equals("*")) {
+
+			// type="explicit" — native Lucene QueryParser syntax, bypass Verity parser
+			if (type == SEARCH_TYPE_EXPLICIT) {
+				if ("*".equals(criteria)) {
+					query = new MatchAllDocsQuery();
+				} else {
+					query = new QueryParser("contents", analyzer).parse(criteria);
+					formatter = new HTMLFormatterWithScore(contextHighlightBegin, contextHighlightEnd);
+				}
+			}
+			// type="simple" (default) — Verity-compatible parser
+			else if ("*".equals(criteria)) {
+				query = new MatchAllDocsQuery();
+			} else {
 				op = queryParser.parseOp(criteria);
 				if (op == null)
 					criteria = "*";
 				else
 					criteria = op.toString();
+			}
 
+			if (query == null && !"*".equals(criteria)) {
 				// Add vector search if enabled and service is available
-				if (getEmbeddingService() != null && !criteria.equals("*")) {
+				if (getEmbeddingService() != null) {
 					try {
 						// Generate embedding for query
 						float[] queryVector = getEmbeddingService().generate(criteria);
@@ -784,8 +797,9 @@ public final class LuceneSearchCollection extends SearchCollectionSupport {
 						}
 					} else {
 						// Normal search
-						TopDocs topDocs = searcher.search(query,
-								maxrow > -1 ? Math.min(startrow + maxrow, reader.numDocs()) : reader.numDocs());
+						int topN = maxrow > -1 ? Math.min(startrow + maxrow, reader.numDocs()) : reader.numDocs();
+						topN = Math.max(1, topN);
+						TopDocs topDocs = searcher.search(query, topN);
 						ScoreDoc[] scoreDocs = topDocs.scoreDocs;
 
 						if (mode == MODE_VECTOR) {

--- a/source/java/src/org/lucee/extension/search/lucene/query/Literal.java
+++ b/source/java/src/org/lucee/extension/search/lucene/query/Literal.java
@@ -3,19 +3,64 @@ package org.lucee.extension.search.lucene.query;
 
 
 public final class Literal implements Op {
-	
+
+	// Lucene special characters that need escaping in user input
+	private static final String LUCENE_SPECIAL = "+-&&||!(){}[]^\"~:\\/";
+
 	String literal;
+	String modifier = "";
+	boolean quoted = false;
 
 	public Literal(String literal) {
 		this.literal=literal;
 	}
 
+	public Literal(String literal, boolean quoted) {
+		this.literal=literal;
+		this.quoted=quoted;
+	}
+
 	@Override
 	public String toString() {
-		return literal;
+		if (quoted)
+			return modifier + "\"" + literal + "\"";
+		return modifier + escapeLuceneSpecialChars(literal);
 	}
 
 	public void set(String literal) {
 		this.literal=literal;
+	}
+
+	public void setModifier(String modifier) {
+		this.modifier=modifier;
+	}
+
+	/**
+	 * Escape Lucene special characters in user input so they don't
+	 * break the QueryParser. Preserves * and ? for wildcards when
+	 * they appear mid-word or trailing (e.g. test*, te?t) but escapes
+	 * them when standalone or leading.
+	 */
+	private static String escapeLuceneSpecialChars(String input) {
+		if (input == null || input.isEmpty()) return input;
+
+		StringBuilder sb = new StringBuilder(input.length() + 4);
+		for (int i = 0; i < input.length(); i++) {
+			char c = input.charAt(i);
+			if (c == '*' || c == '?') {
+				// preserve wildcards that are part of a word (e.g. test*, te?t)
+				// escape standalone or leading wildcards
+				if (i == 0) {
+					sb.append('\\');
+				}
+				sb.append(c);
+			} else if (LUCENE_SPECIAL.indexOf(c) >= 0) {
+				sb.append('\\');
+				sb.append(c);
+			} else {
+				sb.append(c);
+			}
+		}
+		return sb.toString();
 	}
 }

--- a/source/java/src/org/lucee/extension/search/lucene/query/QueryParser.java
+++ b/source/java/src/org/lucee/extension/search/lucene/query/QueryParser.java
@@ -128,9 +128,22 @@ public final class QueryParser {
     
     private Op literal(ParserString ps) {
     	ps.removeSpace();
-    	
-    	if(ps.isCurrent(QUOTER)) return quotedLiteral(ps);
-    	return notQuotedLiteral(ps);
+
+    	// Handle +/- modifiers (Lucene MUST/MUST_NOT) — preserve as prefix on next term
+    	String modifier = "";
+    	if(ps.isValidIndex() && (ps.getCurrent() == '+' || ps.getCurrent() == '-')) {
+    		modifier = String.valueOf(ps.getCurrent());
+    		ps.next();
+    	}
+
+    	Op op;
+    	if(ps.isCurrent(QUOTER)) op = quotedLiteral(ps);
+    	else op = notQuotedLiteral(ps);
+
+    	if(!modifier.isEmpty() && op instanceof Literal) {
+    		((Literal)op).setModifier(modifier);
+    	}
+    	return op;
     }
  
 
@@ -151,9 +164,9 @@ public final class QueryParser {
 			ps.next();
 		}
 		
-		return register(new Literal(str.toString()));
+		return register(new Literal(str.toString(), true));
     }
- 
+
     private Op notQuotedLiteral(ParserString ps) {
     	
 		StringBuffer str=new StringBuffer();

--- a/tests/LDEV1023.cfc
+++ b/tests/LDEV1023.cfc
@@ -1,0 +1,63 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="search" {
+
+	function run( testResults, testBox ) {
+		describe( title="LDEV-1023: non-English language analyzers should not throw ClassNotFoundException", body=function() {
+
+			var languages = [
+				"Arabic", "Bulgarian", "Bengali", "Brazilian", "Catalan",
+				"Czech", "Danish", "Dutch", "English", "Finnish",
+				"French", "German", "Greek", "Hungarian", "Italian",
+				"Japanese", "Korean", "Norwegian", "Portuguese", "Russian",
+				"Spanish", "Swedish", "Thai", "Turkish"
+			];
+
+			for ( var lang in languages ) {
+				it( title="create, index and search with language: #lang#", data={ lang: lang }, body=function( data ) {
+					var safeName = "LDEV1023" & reReplace( data.lang, "[^a-zA-Z]", "", "all" );
+					var path = server._getTempDir( "LDEV1023-#lCase( data.lang )#" );
+
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+					directoryCreate( path );
+
+					try {
+						collection
+							action="create"
+							collection="#safeName#"
+							path="#path#"
+							language="#data.lang#";
+
+						var qry = QueryNew( 'id,title,body' );
+						var row = QueryAddRow( qry );
+						QuerySetCell( qry, "id", "1", row );
+						QuerySetCell( qry, "title", "Language Test", row );
+						QuerySetCell( qry, "body", "Testing the #data.lang# language analyzer works correctly", row );
+
+						index
+							collection="#safeName#"
+							action="update"
+							type="custom"
+							title="title"
+							body="body"
+							key="id"
+							query="qry"
+							urlpath="/";
+
+						search name="local.res" collection="#safeName#" criteria="language" language="#data.lang#";
+						expect( isQuery( res ) ).toBeTrue( "#data.lang# analyzer should return a query" );
+
+						collection
+							action="delete"
+							collection="#safeName#";
+					}
+					finally {
+						if ( DirectoryExists( path ) ) {
+							directoryDelete( path, true );
+						}
+					}
+				});
+			}
+		});
+	}
+}

--- a/tests/LDEV1166.cfc
+++ b/tests/LDEV1166.cfc
@@ -1,0 +1,19 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="search" skip=true {
+
+	// LDEV-1166: Lucene index updates not reflected across servers sharing a SAN path.
+	// This cannot be meaningfully tested in a single-process environment —
+	// it requires multiple Lucee instances pointing at the same index directory.
+	// Skipped; manual validation required in a clustered environment.
+
+	function run( testResults, testBox ) {
+		describe( title="LDEV-1166: shared index across servers (manual test only)", body=function() {
+
+			it( title="placeholder — requires multi-server setup", body=function() {
+				// This ticket describes index updates on server A not being visible
+				// on server B when both share the same collection path via SAN/NFS.
+				// The underlying issue is likely Lucene IndexReader caching.
+				skip( "requires multi-server environment to validate" );
+			});
+		});
+	}
+}

--- a/tests/LDEV1550.cfc
+++ b/tests/LDEV1550.cfc
@@ -1,0 +1,89 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="search" {
+
+	function run( testResults, testBox ) {
+		describe( title="LDEV-1550: corrupt search.xml should not break the site", body=function() {
+
+			it( title="collection operations work after creating a collection on a clean path", body=function() {
+				var path = server._getTempDir( "LDEV1550-clean" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				try {
+					collection
+						action="create"
+						collection="LDEV1550clean"
+						path="#path#"
+						language="English";
+
+					var qry = QueryNew( 'id,title,body' );
+					var row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "1", row );
+					QuerySetCell( qry, "title", "Corrupt Test", row );
+					QuerySetCell( qry, "body", "Testing that search survives after corrupt index files", row );
+
+					index
+						collection="LDEV1550clean"
+						action="update"
+						type="custom"
+						title="title"
+						body="body"
+						key="id"
+						query="qry"
+						urlpath="/";
+
+					search name="local.res" collection="LDEV1550clean" criteria="corrupt" language="English";
+					expect( res.recordcount ).toBe( 1 );
+
+					collection
+						action="delete"
+						collection="LDEV1550clean";
+				}
+				finally {
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+				}
+			});
+
+			it( title="collection list works even when index directory is empty", body=function() {
+				var path = server._getTempDir( "LDEV1550-empty" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				try {
+					collection
+						action="create"
+						collection="LDEV1550empty"
+						path="#path#"
+						language="English";
+
+					// wipe the index files to simulate corruption
+					var indexPath = path & "/LDEV1550EMPTY";
+					if ( DirectoryExists( indexPath ) ) {
+						directoryDelete( indexPath, true );
+						directoryCreate( indexPath );
+					}
+
+					// list should still work without throwing
+					collection action="list" name="local.cols";
+					expect( isQuery( cols ) ).toBeTrue( "collection list should return a query" );
+
+					collection
+						action="delete"
+						collection="LDEV1550empty";
+				}
+				finally {
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+				}
+			});
+		});
+	}
+}

--- a/tests/LDEV1745.cfc
+++ b/tests/LDEV1745.cfc
@@ -1,4 +1,4 @@
-component extends="org.lucee.cfml.test.LuceeTestCase" labels="search" skip=true {
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="search" {
 	function beforeAll(){
 		variables.uri = createURI("LDEV1745");
 	}

--- a/tests/LDEV1879.cfc
+++ b/tests/LDEV1879.cfc
@@ -1,0 +1,262 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="search" {
+
+	function run( testResults, testBox ) {
+		describe( title="LDEV-1879: NPE on cfcollection/cfindex operations", body=function() {
+
+			it( title="cfcollection create does not throw NPE", body=function() {
+				var path = server._getTempDir( "LDEV1879-create" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				try {
+					collection
+						action="create"
+						collection="LDEV1879create"
+						path="#path#"
+						language="English";
+
+					collection action="list" name="local.cols";
+					var found = false;
+					loop query="cols" {
+						if ( cols.name == "LDEV1879CREATE" ) {
+							found = true;
+							break;
+						}
+					}
+					expect( found ).toBeTrue( "collection should appear in list after create" );
+
+					collection
+						action="delete"
+						collection="LDEV1879create";
+				}
+				finally {
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+				}
+			});
+
+			it( title="cfindex and cfsearch work after collection create", body=function() {
+				var path = server._getTempDir( "LDEV1879-index" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				try {
+					collection
+						action="create"
+						collection="LDEV1879idx"
+						path="#path#"
+						language="English";
+
+					var qry = QueryNew( 'id,title,body' );
+					var row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "1", row );
+					QuerySetCell( qry, "title", "Test Doc", row );
+					QuerySetCell( qry, "body", "CFCOLLECTION and CFINDEX should work without NPE", row );
+
+					index
+						collection="LDEV1879idx"
+						action="update"
+						type="custom"
+						title="title"
+						body="body"
+						key="id"
+						query="qry"
+						urlpath="/";
+
+					search name="local.res" collection="LDEV1879idx" criteria="CFINDEX" language="English";
+					expect( res.recordcount ).toBe( 1, "search should find indexed document" );
+
+					collection
+						action="delete"
+						collection="LDEV1879idx";
+				}
+				finally {
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+				}
+			});
+
+			it( title="optimize does not throw NPE", body=function() {
+				var path = server._getTempDir( "LDEV1879-optimize" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				try {
+					collection
+						action="create"
+						collection="LDEV1879opt"
+						path="#path#"
+						language="English";
+
+					var qry = QueryNew( 'id,title,body' );
+					var row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "1", row );
+					QuerySetCell( qry, "title", "Optimize", row );
+					QuerySetCell( qry, "body", "Document to test optimize action", row );
+
+					index
+						collection="LDEV1879opt"
+						action="update"
+						type="custom"
+						title="title"
+						body="body"
+						key="id"
+						query="qry"
+						urlpath="/";
+
+					collection
+						action="optimize"
+						collection="LDEV1879opt";
+
+					search name="local.res" collection="LDEV1879opt" criteria="optimize" language="English";
+					expect( res.recordcount ).toBe( 1, "search should still work after optimize" );
+
+					collection
+						action="delete"
+						collection="LDEV1879opt";
+				}
+				finally {
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+				}
+			});
+
+			it( title="repair does not throw NPE", body=function() {
+				var path = server._getTempDir( "LDEV1879-repair" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				try {
+					collection
+						action="create"
+						collection="LDEV1879rep"
+						path="#path#"
+						language="English";
+
+					var qry = QueryNew( 'id,title,body' );
+					var row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "1", row );
+					QuerySetCell( qry, "title", "Repair", row );
+					QuerySetCell( qry, "body", "Document to test repair action", row );
+
+					index
+						collection="LDEV1879rep"
+						action="update"
+						type="custom"
+						title="title"
+						body="body"
+						key="id"
+						query="qry"
+						urlpath="/";
+
+					collection
+						action="repair"
+						collection="LDEV1879rep";
+
+					search name="local.res" collection="LDEV1879rep" criteria="repair" language="English";
+					expect( res.recordcount ).toBe( 1, "search should still work after repair" );
+
+					collection
+						action="delete"
+						collection="LDEV1879rep";
+				}
+				finally {
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+				}
+			});
+
+			it( title="multiple create/index/search cycles do not cause NPE", body=function() {
+				var path = server._getTempDir( "LDEV1879-cycle" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				try {
+					// cycle 1
+					collection
+						action="create"
+						collection="LDEV1879cyc"
+						path="#path#"
+						language="English";
+
+					var qry = QueryNew( 'id,title,body' );
+					var row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "1", row );
+					QuerySetCell( qry, "title", "Cycle One", row );
+					QuerySetCell( qry, "body", "First cycle document", row );
+
+					index
+						collection="LDEV1879cyc"
+						action="update"
+						type="custom"
+						title="title"
+						body="body"
+						key="id"
+						query="qry"
+						urlpath="/";
+
+					search name="local.res" collection="LDEV1879cyc" criteria="cycle" language="English";
+					expect( res.recordcount ).toBe( 1 );
+
+					collection
+						action="delete"
+						collection="LDEV1879cyc";
+
+					// cycle 2 — reuse same path
+					collection
+						action="create"
+						collection="LDEV1879cyc"
+						path="#path#"
+						language="English";
+
+					var qry2 = QueryNew( 'id,title,body' );
+					row = QueryAddRow( qry2 );
+					QuerySetCell( qry2, "id", "2", row );
+					QuerySetCell( qry2, "title", "Cycle Two", row );
+					QuerySetCell( qry2, "body", "Second cycle document", row );
+
+					index
+						collection="LDEV1879cyc"
+						action="update"
+						type="custom"
+						title="title"
+						body="body"
+						key="id"
+						query="qry2"
+						urlpath="/";
+
+					search name="local.res" collection="LDEV1879cyc" criteria="Second" language="English";
+					expect( res.recordcount ).toBe( 1, "second cycle should work without NPE" );
+
+					collection
+						action="delete"
+						collection="LDEV1879cyc";
+				}
+				finally {
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+				}
+			});
+		});
+	}
+}

--- a/tests/LDEV2025.cfc
+++ b/tests/LDEV2025.cfc
@@ -1,0 +1,77 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="search" {
+
+	function run( testResults, testBox ) {
+		describe( title="LDEV-2025: cfsearch with special characters in criteria", body=function() {
+
+			beforeEach( function() {
+				variables.path = server._getTempDir( "LDEV2025" );
+
+				if ( DirectoryExists( variables.path ) ) {
+					directoryDelete( variables.path, true );
+				}
+				directoryCreate( variables.path );
+
+				collection
+					action="create"
+					collection="LDEV2025"
+					path="#variables.path#"
+					language="English";
+
+				var qry = QueryNew( 'id,title,body' );
+				var row = QueryAddRow( qry );
+				QuerySetCell( qry, "id", "1", row );
+				QuerySetCell( qry, "title", "Question", row );
+				QuerySetCell( qry, "body", "What comes after 5 AAA CCC AAAAA testing lucee lucene", row );
+
+				index
+					collection="LDEV2025"
+					action="update"
+					type="custom"
+					title="title"
+					body="body"
+					key="id"
+					query="qry"
+					urlpath="/";
+			});
+
+			afterEach( function() {
+				try { collection action="delete" collection="LDEV2025"; } catch( any e ) {}
+				if ( DirectoryExists( variables.path ) ) {
+					directoryDelete( variables.path, true );
+				}
+			});
+
+			it( title="criteria with ? between words should not throw", body=function() {
+				search name="local.res" collection="LDEV2025" criteria="What comes after 5 ? AAA CCC AAAAA" language="English";
+				expect( isQuery( res ) ).toBeTrue( "should return a query even with ? in criteria" );
+			});
+
+			it( title="criteria with leading ? should not throw", body=function() {
+				search name="local.res" collection="LDEV2025" criteria="?testing" language="English";
+				expect( isQuery( res ) ).toBeTrue( "should return a query even with leading ?" );
+			});
+
+			it( title="criteria with * wildcard should not throw", body=function() {
+				search name="local.res" collection="LDEV2025" criteria="test*" language="English";
+				expect( isQuery( res ) ).toBeTrue( "should return a query with trailing *" );
+			});
+
+			it( title="criteria with standalone * should not throw", body=function() {
+				search name="local.res" collection="LDEV2025" criteria="*" language="English";
+				expect( isQuery( res ) ).toBeTrue( "should return a query for standalone *" );
+			});
+
+			it( title="criteria with special Lucene chars should not throw", body=function() {
+				// Lucene special chars: + - && || ! ( ) { } [ ] ^ " ~ * ? : \ /
+				var specials = [ "test + lucee", "test - lucee", "test && lucee",
+					"test || lucee", "test ! lucee", "(test)", "{test}",
+					"[test]", "test^2", "~test", "test:lucee" ];
+
+				for ( var criteria in specials ) {
+					search name="local.res" collection="LDEV2025" criteria="#criteria#" language="English";
+					expect( isQuery( res ) ).toBeTrue( "should handle criteria: #criteria#" );
+				}
+			});
+		});
+	}
+}

--- a/tests/LDEV2032.cfc
+++ b/tests/LDEV2032.cfc
@@ -1,0 +1,136 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="search" {
+
+	function run( testResults, testBox ) {
+		describe( title="LDEV-2032: collections should persist and be listed after creation", body=function() {
+
+			it( title="collection appears in list immediately after create", body=function() {
+				var path = server._getTempDir( "LDEV2032-persist" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				try {
+					collection
+						action="create"
+						collection="LDEV2032per"
+						path="#path#"
+						language="English";
+
+					collection action="list" name="local.cols";
+					var found = false;
+					loop query="cols" {
+						if ( cols.name == "LDEV2032PER" ) {
+							found = true;
+							break;
+						}
+					}
+					expect( found ).toBeTrue( "collection should be in list after create" );
+
+					collection
+						action="delete"
+						collection="LDEV2032per";
+				}
+				finally {
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+				}
+			});
+
+			it( title="multiple collections all appear in list", body=function() {
+				var path = server._getTempDir( "LDEV2032-multi" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				try {
+					collection
+						action="create"
+						collection="LDEV2032mA"
+						path="#path#/colA"
+						language="English";
+
+					collection
+						action="create"
+						collection="LDEV2032mB"
+						path="#path#/colB"
+						language="English";
+
+					collection
+						action="create"
+						collection="LDEV2032mC"
+						path="#path#/colC"
+						language="English";
+
+					collection action="list" name="local.cols";
+					var names = valueList( cols.name );
+					expect( names ).toInclude( "LDEV2032MA", "collection A should be listed" );
+					expect( names ).toInclude( "LDEV2032MB", "collection B should be listed" );
+					expect( names ).toInclude( "LDEV2032MC", "collection C should be listed" );
+
+					collection action="delete" collection="LDEV2032mA";
+					collection action="delete" collection="LDEV2032mB";
+					collection action="delete" collection="LDEV2032mC";
+				}
+				finally {
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+				}
+			});
+
+			it( title="indexed data persists and is searchable after re-listing", body=function() {
+				var path = server._getTempDir( "LDEV2032-data" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				try {
+					collection
+						action="create"
+						collection="LDEV2032dat"
+						path="#path#"
+						language="English";
+
+					var qry = QueryNew( 'id,title,body' );
+					var row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "1", row );
+					QuerySetCell( qry, "title", "Persist Doc", row );
+					QuerySetCell( qry, "body", "This document should survive across list operations", row );
+
+					index
+						collection="LDEV2032dat"
+						action="update"
+						type="custom"
+						title="title"
+						body="body"
+						key="id"
+						query="qry"
+						urlpath="/";
+
+					// list collections (simulates what the admin does)
+					collection action="list" name="local.cols";
+
+					// search should still work
+					search name="local.res" collection="LDEV2032dat" criteria="document" language="English";
+					expect( res.recordcount ).toBe( 1, "data should persist and be searchable" );
+
+					collection
+						action="delete"
+						collection="LDEV2032dat";
+				}
+				finally {
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+				}
+			});
+		});
+	}
+}

--- a/tests/LDEV3310.cfc
+++ b/tests/LDEV3310.cfc
@@ -1,0 +1,124 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="search" {
+
+	function run( testResults, testBox ) {
+		describe( title="LDEV-3310: cfcollection delete should not leave locked files on Windows", body=function() {
+
+			it( title="collection delete removes index directory cleanly", body=function() {
+				var path = server._getTempDir( "LDEV3310-delete" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				collection
+					action="create"
+					collection="LDEV3310del"
+					path="#path#"
+					language="English";
+
+				var qry = QueryNew( 'id,title,body' );
+				var row = QueryAddRow( qry );
+				QuerySetCell( qry, "id", "1", row );
+				QuerySetCell( qry, "title", "Lock Test", row );
+				QuerySetCell( qry, "body", "Testing that index files are not locked after delete", row );
+
+				index
+					collection="LDEV3310del"
+					action="update"
+					type="custom"
+					title="title"
+					body="body"
+					key="id"
+					query="qry"
+					urlpath="/";
+
+				// verify the index was created
+				search name="local.res" collection="LDEV3310del" criteria="locked" language="English";
+				expect( res.recordcount ).toBe( 1 );
+
+				collection
+					action="delete"
+					collection="LDEV3310del";
+
+				// the index directory should be deletable (no locked files)
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				expect( DirectoryExists( path ) ).toBeFalse( "directory should be fully deleted without locked files" );
+			});
+
+			it( title="collection delete followed by recreate works", body=function() {
+				var path = server._getTempDir( "LDEV3310-recreate" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				try {
+					collection
+						action="create"
+						collection="LDEV3310rec"
+						path="#path#"
+						language="English";
+
+					var qry = QueryNew( 'id,title,body' );
+					var row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "1", row );
+					QuerySetCell( qry, "title", "First", row );
+					QuerySetCell( qry, "body", "First version of the collection", row );
+
+					index
+						collection="LDEV3310rec"
+						action="update"
+						type="custom"
+						title="title"
+						body="body"
+						key="id"
+						query="qry"
+						urlpath="/";
+
+					collection
+						action="delete"
+						collection="LDEV3310rec";
+
+					// recreate on same path
+					collection
+						action="create"
+						collection="LDEV3310rec"
+						path="#path#"
+						language="English";
+
+					var qry2 = QueryNew( 'id,title,body' );
+					row = QueryAddRow( qry2 );
+					QuerySetCell( qry2, "id", "2", row );
+					QuerySetCell( qry2, "title", "Second", row );
+					QuerySetCell( qry2, "body", "Recreated collection content", row );
+
+					index
+						collection="LDEV3310rec"
+						action="update"
+						type="custom"
+						title="title"
+						body="body"
+						key="id"
+						query="qry2"
+						urlpath="/";
+
+					search name="local.res" collection="LDEV3310rec" criteria="Recreated" language="English";
+					expect( res.recordcount ).toBe( 1, "recreated collection should be searchable" );
+
+					collection
+						action="delete"
+						collection="LDEV3310rec";
+				}
+				finally {
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+				}
+			});
+		});
+	}
+}

--- a/tests/LDEV3310.cfc
+++ b/tests/LDEV3310.cfc
@@ -41,11 +41,11 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="search" {
 					action="delete"
 					collection="LDEV3310del";
 
-				// the index directory should be deletable (no locked files)
+				// verify the directory can be cleaned up (LDEV-3310: previously failed on Windows due to locked index files)
 				if ( DirectoryExists( path ) ) {
 					directoryDelete( path, true );
 				}
-				expect( DirectoryExists( path ) ).toBeFalse( "directory should be fully deleted without locked files" );
+				expect( DirectoryExists( path ) ).toBeFalse( "directory should be fully deleted after collection delete" );
 			});
 
 			it( title="collection delete followed by recreate works", body=function() {

--- a/tests/LDEV6193.cfc
+++ b/tests/LDEV6193.cfc
@@ -1,0 +1,116 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="search" {
+
+	function beforeAll() {
+		variables.path = server._getTempDir( "LDEV6193" );
+
+		if ( DirectoryExists( variables.path ) ) {
+			directoryDelete( variables.path, true );
+		}
+		directoryCreate( variables.path );
+
+		collection
+			action="create"
+			collection="LDEV6193"
+			path="#variables.path#"
+			language="English";
+
+		var qry = QueryNew( 'id,title,body' );
+
+		var row = QueryAddRow( qry );
+		QuerySetCell( qry, "id", "1", row );
+		QuerySetCell( qry, "title", "Lucee Server", row );
+		QuerySetCell( qry, "body", "Lucee is an open source CFML application server written in Java", row );
+
+		row = QueryAddRow( qry );
+		QuerySetCell( qry, "id", "2", row );
+		QuerySetCell( qry, "title", "Apache Tomcat", row );
+		QuerySetCell( qry, "body", "Tomcat is a Java servlet container for running web applications", row );
+
+		row = QueryAddRow( qry );
+		QuerySetCell( qry, "id", "3", row );
+		QuerySetCell( qry, "title", "Python Flask", row );
+		QuerySetCell( qry, "body", "Flask is a lightweight Python web framework for building APIs", row );
+
+		index
+			collection="LDEV6193"
+			action="update"
+			type="custom"
+			title="title"
+			body="body"
+			key="id"
+			query="qry"
+			urlpath="/";
+	}
+
+	function afterAll() {
+		try { collection action="delete" collection="LDEV6193"; } catch( any e ) {}
+		if ( DirectoryExists( variables.path ) ) {
+			directoryDelete( variables.path, true );
+		}
+	}
+
+	function run( testResults, testBox ) {
+		describe( title="LDEV-6193: type=explicit for native Lucene query syntax", body=function() {
+
+			it( title="basic term search with type=explicit", body=function() {
+				search name="local.res" collection="LDEV6193" criteria="Lucee" type="explicit" language="English";
+				expect( res.recordcount ).toBe( 1 );
+			});
+
+			it( title="+MUST modifier", body=function() {
+				search name="local.res" collection="LDEV6193" criteria="+Java +open" type="explicit" language="English";
+				expect( res.recordcount ).toBe( 1, "should only match the doc with both Java AND open" );
+			});
+
+			it( title="-MUST_NOT modifier", body=function() {
+				search name="local.res" collection="LDEV6193" criteria="Java -servlet" type="explicit" language="English";
+				expect( res.recordcount ).toBe( 1, "should match Java doc but exclude servlet doc" );
+			});
+
+			it( title="wildcard with ?", body=function() {
+				search name="local.res" collection="LDEV6193" criteria="Luce?" type="explicit" language="English";
+				expect( res.recordcount ).toBe( 1 );
+			});
+
+			it( title="wildcard with *", body=function() {
+				search name="local.res" collection="LDEV6193" criteria="serv*" type="explicit" language="English";
+				expect( res.recordcount ).toBeGT( 0, "should match server and/or servlet" );
+			});
+
+			it( title="phrase query", body=function() {
+				search name="local.res" collection="LDEV6193" criteria='"open source"' type="explicit" language="English";
+				expect( res.recordcount ).toBe( 1 );
+			});
+
+			it( title="boolean grouping", body=function() {
+				search name="local.res" collection="LDEV6193" criteria="(Java OR Python) AND web" type="explicit" language="English";
+				expect( res.recordcount ).toBe( 2, "should match Tomcat and Flask docs" );
+			});
+
+			it( title="fuzzy search", body=function() {
+				search name="local.res" collection="LDEV6193" criteria="Luce~1" type="explicit" language="English";
+				expect( res.recordcount ).toBeGT( 0, "fuzzy match should find Lucee" );
+			});
+
+			it( title="boost", body=function() {
+				search name="local.res" collection="LDEV6193" criteria="Java^4 Python" type="explicit" language="English";
+				expect( res.recordcount ).toBeGT( 0, "boosted query should return results" );
+			});
+
+			it( title="criteria=* returns all docs", body=function() {
+				search name="local.res" collection="LDEV6193" criteria="*" type="explicit" language="English";
+				expect( res.recordcount ).toBe( 3, "should return all documents" );
+			});
+
+			it( title="type=simple still works (regression)", body=function() {
+				search name="local.res" collection="LDEV6193" criteria="Lucee" type="simple" language="English";
+				expect( res.recordcount ).toBe( 1 );
+			});
+
+			it( title="no type defaults to simple (regression)", body=function() {
+				search name="local.res" collection="LDEV6193" criteria="Lucee" language="English";
+				expect( res.recordcount ).toBe( 1 );
+			});
+		});
+	}
+}

--- a/tests/LDEV6194.cfc
+++ b/tests/LDEV6194.cfc
@@ -1,0 +1,131 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="search" {
+
+	function beforeAll() {
+		variables.path = server._getTempDir( "LDEV6194" );
+
+		if ( DirectoryExists( variables.path ) ) {
+			directoryDelete( variables.path, true );
+		}
+		directoryCreate( variables.path );
+
+		collection
+			action="create"
+			collection="LDEV6194"
+			path="#variables.path#"
+			language="English";
+
+		var qry = QueryNew( 'id,title,body' );
+
+		var row = QueryAddRow( qry );
+		QuerySetCell( qry, "id", "1", row );
+		QuerySetCell( qry, "title", "Test Document", row );
+		QuerySetCell( qry, "body", "What comes after 5 in this sequence of numbers and letters AAA CCC", row );
+
+		row = QueryAddRow( qry );
+		QuerySetCell( qry, "id", "2", row );
+		QuerySetCell( qry, "title", "Another Document", row );
+		QuerySetCell( qry, "body", "Testing the Lucee search extension with various queries", row );
+
+		index
+			collection="LDEV6194"
+			action="update"
+			type="custom"
+			title="title"
+			body="body"
+			key="id"
+			query="qry"
+			urlpath="/";
+	}
+
+	function afterAll() {
+		try { collection action="delete" collection="LDEV6194"; } catch( any e ) {}
+		if ( DirectoryExists( variables.path ) ) {
+			directoryDelete( variables.path, true );
+		}
+	}
+
+	function run( testResults, testBox ) {
+		describe( title="LDEV-6194: Verity query parser bug fixes", body=function() {
+
+			// Fix 1: MatchAllDocsQuery for criteria="*"
+			it( title="criteria=* returns all docs without NPE", body=function() {
+				search name="local.res" collection="LDEV6194" criteria="*" language="English";
+				expect( res.recordcount ).toBe( 2, "should return all documents" );
+			});
+
+			it( title="criteria=* with startRow", body=function() {
+				search name="local.res" collection="LDEV6194" criteria="*" language="English" startRow="1" maxRows="1";
+				expect( res.recordcount ).toBe( 1, "should return one document with maxRows=1" );
+			});
+
+			// Fix 2: Guard topN parameter
+			it( title="search with zero results does not throw numHits error", body=function() {
+				search name="local.res" collection="LDEV6194" criteria="xyznonexistent" language="English";
+				expect( res.recordcount ).toBe( 0 );
+				expect( isQuery( res ) ).toBeTrue();
+			});
+
+			it( title="phrase query with no matches does not throw", body=function() {
+				search name="local.res" collection="LDEV6194" criteria='"no such phrase exists anywhere"' language="English";
+				expect( res.recordcount ).toBe( 0 );
+			});
+
+			// Fix 3: Escape special characters
+			it( title="? between words does not throw", body=function() {
+				search name="local.res" collection="LDEV6194" criteria="What comes after 5 ? AAA CCC" language="English";
+				expect( isQuery( res ) ).toBeTrue( "should return a query even with ? in criteria" );
+			});
+
+			it( title="standalone * does not NPE", body=function() {
+				search name="local.res" collection="LDEV6194" criteria="*" language="English";
+				expect( isQuery( res ) ).toBeTrue();
+			});
+
+			it( title="unbalanced ) does not throw", body=function() {
+				search name="local.res" collection="LDEV6194" criteria="test)" language="English";
+				expect( isQuery( res ) ).toBeTrue( "should handle unbalanced )" );
+			});
+
+			it( title="unbalanced ] does not throw", body=function() {
+				search name="local.res" collection="LDEV6194" criteria="test]" language="English";
+				expect( isQuery( res ) ).toBeTrue( "should handle unbalanced ]" );
+			});
+
+			it( title="curly braces do not throw", body=function() {
+				search name="local.res" collection="LDEV6194" criteria="{test}" language="English";
+				expect( isQuery( res ) ).toBeTrue( "should handle curly braces" );
+			});
+
+			it( title="colon in criteria does not throw", body=function() {
+				search name="local.res" collection="LDEV6194" criteria="test:value" language="English";
+				expect( isQuery( res ) ).toBeTrue( "should handle colon" );
+			});
+
+			it( title="tilde in criteria does not throw", body=function() {
+				search name="local.res" collection="LDEV6194" criteria="test~" language="English";
+				expect( isQuery( res ) ).toBeTrue( "should handle tilde" );
+			});
+
+			it( title="caret in criteria does not throw", body=function() {
+				search name="local.res" collection="LDEV6194" criteria="test^2" language="English";
+				expect( isQuery( res ) ).toBeTrue( "should handle caret/boost" );
+			});
+
+			// Regression: normal searches still work
+			it( title="normal word search still works", body=function() {
+				search name="local.res" collection="LDEV6194" criteria="Lucee" language="English";
+				expect( res.recordcount ).toBe( 1 );
+			});
+
+			it( title="AND/OR/NOT still work", body=function() {
+				search name="local.res" collection="LDEV6194" criteria="Lucee OR numbers" language="English";
+				expect( res.recordcount ).toBe( 2 );
+			});
+
+			it( title="quoted phrase still works", body=function() {
+				search name="local.res" collection="LDEV6194" criteria='"search extension"' language="English";
+				expect( res.recordcount ).toBe( 1 );
+			});
+		});
+	}
+}


### PR DESCRIPTION
## Summary

- Fix NPE on `criteria="*"` (MatchAllDocsQuery)
- Guard topN parameter for empty results (Lucene 9 compat)
- Escape special characters in Verity parser output
- Handle `+`/`-` modifiers in Verity parser
- `type="explicit"` bypasses Verity parser, enables native Lucene QueryParser syntax

Fixes [LDEV-2025](https://luceeserver.atlassian.net/browse/LDEV-2025), [LDEV-1745](https://luceeserver.atlassian.net/browse/LDEV-1745)

Epic: [LDEV-6191](https://luceeserver.atlassian.net/browse/LDEV-6191)
Tickets: [LDEV-6193](https://luceeserver.atlassian.net/browse/LDEV-6193), [LDEV-6194](https://luceeserver.atlassian.net/browse/LDEV-6194)