### PR TITLE
LDEV-6195, LDEV-6197: fix delete action and filename search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.0.167
+
+- [LDEV-6195](https://luceeserver.atlassian.net/browse/LDEV-6195) — fix `cfindex action="delete"` not removing individual documents
+- [LDEV-6197](https://luceeserver.atlassian.net/browse/LDEV-6197) — make filenames searchable in path-type indexes
+
 ## 3.0.0.166
 
 - [LDEV-6194](https://luceeserver.atlassian.net/browse/LDEV-6194) — fix NPE on `criteria="*"`, guard topN for empty results, escape special chars in Verity parser

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.lucee</groupId>
     <artifactId>lucene-search-extension</artifactId>
-    <version>3.0.0.166-SNAPSHOT</version>
+    <version>3.0.0.167-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Lucene Search Engine</name>
 

--- a/source/java/src/org/lucee/extension/search/SearchCollectionSupport.java
+++ b/source/java/src/org/lucee/extension/search/SearchCollectionSupport.java
@@ -537,7 +537,17 @@ public abstract class SearchCollectionSupport implements SearchCollection {
 				}
 
 				QueryColumn keyColumn = qv.getColumn(k);
-				return deleteCustom("custom", keyColumn);
+
+				// apply delete across all custom indexes — the index id is derived
+				// from the query variable name used at index time, which we don't
+				// know here, so we iterate all custom-type indexes
+				IndexResult ir = IndexResultImpl.EMPTY;
+				for (SearchIndex si : indexes.values()) {
+					if (si.getType() == SearchIndex.TYPE_CUSTOM) {
+						ir = deleteCustom(si.getId(), keyColumn);
+					}
+				}
+				return ir;
 			} catch (PageException pe) {
 				throw CommonUtil.toSearchException(pe);
 			}

--- a/source/java/src/org/lucee/extension/search/lucene/DocumentUtil.java
+++ b/source/java/src/org/lucee/extension/search/lucene/DocumentUtil.java
@@ -81,6 +81,12 @@ public final class DocumentUtil {
 			doc.add(FieldUtil.UnIndexed("url", strPath));
 			doc.add(FieldUtil.UnIndexed("key", strPath));
 			doc.add(FieldUtil.UnIndexed("path", strPath));
+			// add filename from URL as searchable field
+			String urlPath = url.getPath();
+			if (urlPath != null && !urlPath.isEmpty()) {
+				String urlName = urlPath.substring(urlPath.lastIndexOf('/') + 1);
+				if (!urlName.isEmpty()) doc.add(FieldUtil.Text("filename", urlName));
+			}
 		}
 
 		return doc;
@@ -151,6 +157,14 @@ public final class DocumentUtil {
 		doc.add(FieldUtil.UnIndexed("url", strName));
 		doc.add(FieldUtil.UnIndexed("key", strPath));
 		doc.add(FieldUtil.UnIndexed("path", file.getPath()));
+		// add filename as searchable field so cfsearch can find files by name
+		String searchableName = strName.startsWith("/") ? strName.substring(1) : strName;
+		// index both with and without extension for maximum searchability
+		doc.add(FieldUtil.Text("filename", searchableName));
+		int dotPos = searchableName.lastIndexOf('.');
+		if (dotPos > 0) {
+			doc.add(FieldUtil.Text("filename", searchableName.substring(0, dotPos)));
+		}
 		doc.add(FieldUtil.UnIndexed("size", e.getCastUtil().toString(file.length())));
 		doc.add(new StringField("modified",
 				DateTools.timeToString(file.lastModified(), DateTools.Resolution.MILLISECOND), Field.Store.YES));

--- a/source/java/src/org/lucee/extension/search/lucene/LuceneSearchCollection.java
+++ b/source/java/src/org/lucee/extension/search/lucene/LuceneSearchCollection.java
@@ -28,6 +28,7 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexWriterConfig.OpenMode;
 import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.queryparser.classic.MultiFieldQueryParser;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -667,7 +668,7 @@ public final class LuceneSearchCollection extends SearchCollectionSupport {
 				if ("*".equals(criteria)) {
 					query = new MatchAllDocsQuery();
 				} else {
-					query = new QueryParser("contents", analyzer).parse(criteria);
+					query = new MultiFieldQueryParser(new String[] { "contents", "filename" }, analyzer).parse(criteria);
 					formatter = new HTMLFormatterWithScore(contextHighlightBegin, contextHighlightEnd);
 				}
 			}
@@ -697,7 +698,7 @@ public final class LuceneSearchCollection extends SearchCollectionSupport {
 
 						if (mode == MODE_HYBRID) {
 
-							Query keywordQuery = new QueryParser("contents", analyzer).parse(criteria);
+							Query keywordQuery = new MultiFieldQueryParser(new String[] { "contents", "filename" }, analyzer).parse(criteria);
 							// Combine queries for hybrid search
 							BooleanQuery.Builder bqBuilder = new BooleanQuery.Builder();
 							BoostQuery boostedKeywordQuery = new BoostQuery(keywordQuery, keywordWeight);
@@ -721,7 +722,7 @@ public final class LuceneSearchCollection extends SearchCollectionSupport {
 				}
 
 				else {
-					query = new QueryParser("contents", analyzer).parse(criteria);
+					query = new MultiFieldQueryParser(new String[] { "contents", "filename" }, analyzer).parse(criteria);
 				}
 
 				formatter = new HTMLFormatterWithScore(contextHighlightBegin, contextHighlightEnd);

--- a/tests/LDEV6195.cfc
+++ b/tests/LDEV6195.cfc
@@ -1,0 +1,156 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="search" {
+
+	function run( testResults, testBox ) {
+		describe( title="LDEV-6195: cfindex action=delete should remove individual documents", body=function() {
+
+			it( title="delete by key removes specific document from index", body=function() {
+				var path = server._getTempDir( "index-delete-key" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				try {
+					collection
+						action="create"
+						collection="deleteByKey"
+						path="#path#"
+						language="English";
+
+					var qry = QueryNew( 'id,title,body' );
+					var row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "1", row );
+					QuerySetCell( qry, "title", "Keep This", row );
+					QuerySetCell( qry, "body", "Document that should survive deletion xylophone", row );
+
+					row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "2", row );
+					QuerySetCell( qry, "title", "Delete This", row );
+					QuerySetCell( qry, "body", "Document that should be removed zeppelin", row );
+
+					row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "3", row );
+					QuerySetCell( qry, "title", "Also Keep", row );
+					QuerySetCell( qry, "body", "Another document that should survive accordion", row );
+
+					index
+						collection="deleteByKey"
+						action="update"
+						type="custom"
+						title="title"
+						body="body"
+						key="id"
+						query="qry"
+						urlpath="/";
+
+					// verify all 3 indexed
+					search name="local.res" collection="deleteByKey" criteria="document" language="English";
+					expect( res.recordcount ).toBe( 3, "should find all 3 documents before delete" );
+
+					// delete document with key "2"
+					var delQry = QueryNew( 'id,title,body' );
+					row = QueryAddRow( delQry );
+					QuerySetCell( delQry, "id", "2", row );
+					QuerySetCell( delQry, "title", "", row );
+					QuerySetCell( delQry, "body", "", row );
+
+					index
+						collection="deleteByKey"
+						action="delete"
+						type="custom"
+						key="id"
+						query="delQry";
+
+					// verify document 2 is gone
+					search name="local.res" collection="deleteByKey" criteria="zeppelin" language="English";
+					expect( res.recordcount ).toBe( 0, "deleted document should not be found" );
+
+					// verify other documents still exist
+					search name="local.res" collection="deleteByKey" criteria="xylophone" language="English";
+					expect( res.recordcount ).toBe( 1, "non-deleted document 1 should still be found" );
+
+					search name="local.res" collection="deleteByKey" criteria="accordion" language="English";
+					expect( res.recordcount ).toBe( 1, "non-deleted document 3 should still be found" );
+
+					collection action="delete" collection="deleteByKey";
+				}
+				finally {
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+				}
+			});
+
+			it( title="delete then re-search does not return stale results", body=function() {
+				var path = server._getTempDir( "index-delete-stale" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				try {
+					collection
+						action="create"
+						collection="deleteStale"
+						path="#path#"
+						language="English";
+
+					var qry = QueryNew( 'id,title,body' );
+					var row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "100", row );
+					QuerySetCell( qry, "title", "Persistent", row );
+					QuerySetCell( qry, "body", "This persistent searchable document stays forever", row );
+
+					row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "200", row );
+					QuerySetCell( qry, "title", "Ephemeral", row );
+					QuerySetCell( qry, "body", "This ephemeral searchable document gets deleted", row );
+
+					index
+						collection="deleteStale"
+						action="update"
+						type="custom"
+						title="title"
+						body="body"
+						key="id"
+						query="qry"
+						urlpath="/";
+
+					search name="local.res" collection="deleteStale" criteria="searchable" language="English";
+					expect( res.recordcount ).toBe( 2, "both documents should be found initially" );
+
+					// delete ephemeral document
+					var delQry = QueryNew( 'id,title,body' );
+					row = QueryAddRow( delQry );
+					QuerySetCell( delQry, "id", "200", row );
+					QuerySetCell( delQry, "title", "", row );
+					QuerySetCell( delQry, "body", "", row );
+
+					index
+						collection="deleteStale"
+						action="delete"
+						type="custom"
+						key="id"
+						query="delQry";
+
+					// search with a term that matched both documents
+					search name="local.res" collection="deleteStale" criteria="searchable" language="English";
+					expect( res.recordcount ).toBe( 1, "only persistent document should remain" );
+
+					// search specifically for deleted content
+					search name="local.res" collection="deleteStale" criteria="ephemeral" language="English";
+					expect( res.recordcount ).toBe( 0, "ephemeral document should be completely gone" );
+
+					collection action="delete" collection="deleteStale";
+				}
+				finally {
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+				}
+			});
+		});
+	}
+}

--- a/tests/LDEV6197.cfc
+++ b/tests/LDEV6197.cfc
@@ -1,0 +1,111 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="search" {
+
+	function run( testResults, testBox ) {
+		describe( title="LDEV-6197: cfsearch filename not searchable in path-type index", body=function() {
+
+			it( title="filename is searchable in path-type index", body=function() {
+				var filePath = server._getTempDir( "path-filename-files" );
+				var collPath = server._getTempDir( "path-filename-coll" );
+
+				if ( DirectoryExists( filePath ) ) {
+					directoryDelete( filePath, true );
+				}
+				directoryCreate( filePath );
+				if ( DirectoryExists( collPath ) ) {
+					directoryDelete( collPath, true );
+				}
+				directoryCreate( collPath );
+
+				try {
+					fileWrite( filePath & "/Marrakesh.html", "<html><body>Travel guide to Morocco</body></html>", "UTF-8" );
+					fileWrite( filePath & "/Tokyo.html", "<html><body>Travel guide to Japan</body></html>", "UTF-8" );
+					fileWrite( filePath & "/Berlin.html", "<html><body>Travel guide to Germany</body></html>", "UTF-8" );
+
+					collection
+						action="create"
+						collection="pathFilename"
+						path="#collPath#"
+						language="English";
+
+					index
+						collection="pathFilename"
+						action="update"
+						key="#filePath#"
+						type="path"
+						urlpath="/travel/"
+						extensions=".html"
+						recurse="true";
+
+					// search by filename — this is the reported bug
+					search name="local.res" collection="pathFilename" criteria="Marrakesh" language="English";
+					expect( res.recordcount ).toBeGTE( 1, "should find document by filename 'Marrakesh'" );
+
+					// search by content to verify indexing worked at all
+					search name="local.res" collection="pathFilename" criteria="Morocco" language="English";
+					expect( res.recordcount ).toBe( 1, "should find document by content 'Morocco'" );
+
+					// search by another filename
+					search name="local.res" collection="pathFilename" criteria="Tokyo" language="English";
+					expect( res.recordcount ).toBeGTE( 1, "should find document by filename 'Tokyo'" );
+
+					collection action="delete" collection="pathFilename";
+				}
+				finally {
+					if ( DirectoryExists( filePath ) ) {
+						directoryDelete( filePath, true );
+					}
+					if ( DirectoryExists( collPath ) ) {
+						directoryDelete( collPath, true );
+					}
+				}
+			});
+
+			it( title="URL path is returned in search results for path-type index", body=function() {
+				var filePath = server._getTempDir( "path-url-files" );
+				var collPath = server._getTempDir( "path-url-coll" );
+
+				if ( DirectoryExists( filePath ) ) {
+					directoryDelete( filePath, true );
+				}
+				directoryCreate( filePath );
+				if ( DirectoryExists( collPath ) ) {
+					directoryDelete( collPath, true );
+				}
+				directoryCreate( collPath );
+
+				try {
+					fileWrite( filePath & "/sample.html", "<html><body>Unique xylophone content for URL test</body></html>", "UTF-8" );
+
+					collection
+						action="create"
+						collection="pathUrl"
+						path="#collPath#"
+						language="English";
+
+					index
+						collection="pathUrl"
+						action="update"
+						key="#filePath#"
+						type="path"
+						urlpath="/mysite/"
+						extensions=".html"
+						recurse="true";
+
+					search name="local.res" collection="pathUrl" criteria="xylophone" language="English";
+					expect( res.recordcount ).toBe( 1 );
+					expect( res.key ).toInclude( "sample.html", "key should contain the filename" );
+
+					collection action="delete" collection="pathUrl";
+				}
+				finally {
+					if ( DirectoryExists( filePath ) ) {
+						directoryDelete( filePath, true );
+					}
+					if ( DirectoryExists( collPath ) ) {
+						directoryDelete( collPath, true );
+					}
+				}
+			});
+		});
+	}
+}

--- a/tests/PurgeAndReindex.cfc
+++ b/tests/PurgeAndReindex.cfc
@@ -1,0 +1,169 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="search" {
+
+	function run( testResults, testBox ) {
+		describe( title="Forum: purge + re-index should not return stale records", body=function() {
+
+			it( title="purge then re-index with fewer records does not return old data", body=function() {
+				var path = server._getTempDir( "purge-reindex" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				try {
+					collection
+						action="create"
+						collection="purgeReindex"
+						path="#path#"
+						language="English";
+
+					// index 3 documents
+					var qry = QueryNew( 'id,title,body' );
+					var row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "1", row );
+					QuerySetCell( qry, "title", "Alpha", row );
+					QuerySetCell( qry, "body", "Alpha document about searchable content", row );
+
+					row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "2", row );
+					QuerySetCell( qry, "title", "Beta", row );
+					QuerySetCell( qry, "body", "Beta document about searchable content", row );
+
+					row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "3", row );
+					QuerySetCell( qry, "title", "Gamma", row );
+					QuerySetCell( qry, "body", "Gamma document about searchable content", row );
+
+					index
+						collection="purgeReindex"
+						action="update"
+						type="custom"
+						title="title"
+						body="body"
+						key="id"
+						query="qry"
+						urlpath="/";
+
+					search name="local.res" collection="purgeReindex" criteria="searchable" language="English";
+					expect( res.recordcount ).toBe( 3, "should find all 3 documents before purge" );
+
+					// purge all documents
+					index collection="purgeReindex" action="purge";
+
+					search name="local.res" collection="purgeReindex" criteria="searchable" language="English";
+					expect( res.recordcount ).toBe( 0, "should find 0 documents after purge" );
+
+					// re-index with only 1 document
+					var qry2 = QueryNew( 'id,title,body' );
+					row = QueryAddRow( qry2 );
+					QuerySetCell( qry2, "id", "10", row );
+					QuerySetCell( qry2, "title", "Delta", row );
+					QuerySetCell( qry2, "body", "Delta is the only searchable document now", row );
+
+					index
+						collection="purgeReindex"
+						action="update"
+						type="custom"
+						title="title"
+						body="body"
+						key="id"
+						query="qry2"
+						urlpath="/";
+
+					search name="local.res" collection="purgeReindex" criteria="searchable" language="English";
+					expect( res.recordcount ).toBe( 1, "should find only 1 document after re-index" );
+
+					// verify old documents are truly gone
+					search name="local.res" collection="purgeReindex" criteria="Alpha" language="English";
+					expect( res.recordcount ).toBe( 0, "old document Alpha should not be found" );
+
+					search name="local.res" collection="purgeReindex" criteria="Beta" language="English";
+					expect( res.recordcount ).toBe( 0, "old document Beta should not be found" );
+
+					search name="local.res" collection="purgeReindex" criteria="Gamma" language="English";
+					expect( res.recordcount ).toBe( 0, "old document Gamma should not be found" );
+
+					collection action="delete" collection="purgeReindex";
+				}
+				finally {
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+				}
+			});
+
+			it( title="refresh replaces all documents without needing explicit purge", body=function() {
+				var path = server._getTempDir( "refresh-reindex" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				try {
+					collection
+						action="create"
+						collection="refreshReindex"
+						path="#path#"
+						language="English";
+
+					// index 2 documents
+					var qry = QueryNew( 'id,title,body' );
+					var row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "1", row );
+					QuerySetCell( qry, "title", "Original One", row );
+					QuerySetCell( qry, "body", "Original first document zeppelin", row );
+
+					row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "2", row );
+					QuerySetCell( qry, "title", "Original Two", row );
+					QuerySetCell( qry, "body", "Original second document zeppelin", row );
+
+					index
+						collection="refreshReindex"
+						action="update"
+						type="custom"
+						title="title"
+						body="body"
+						key="id"
+						query="qry"
+						urlpath="/";
+
+					search name="local.res" collection="refreshReindex" criteria="zeppelin" language="English";
+					expect( res.recordcount ).toBe( 2 );
+
+					// refresh with only 1 different document
+					var qry2 = QueryNew( 'id,title,body' );
+					row = QueryAddRow( qry2 );
+					QuerySetCell( qry2, "id", "3", row );
+					QuerySetCell( qry2, "title", "Replacement", row );
+					QuerySetCell( qry2, "body", "This completely replaces the index xylophone", row );
+
+					index
+						collection="refreshReindex"
+						action="refresh"
+						type="custom"
+						title="title"
+						body="body"
+						key="id"
+						query="qry2"
+						urlpath="/";
+
+					search name="local.res" collection="refreshReindex" criteria="zeppelin" language="English";
+					expect( res.recordcount ).toBe( 0, "original documents should be gone after refresh" );
+
+					search name="local.res" collection="refreshReindex" criteria="xylophone" language="English";
+					expect( res.recordcount ).toBe( 1, "replacement document should be found" );
+
+					collection action="delete" collection="refreshReindex";
+				}
+				finally {
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+				}
+			});
+		});
+	}
+}

--- a/tests/WildcardStarSearch.cfc
+++ b/tests/WildcardStarSearch.cfc
@@ -1,0 +1,172 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="search" {
+
+	function run( testResults, testBox ) {
+		describe( title="Bug: NPE when using wildcard * criteria with cfsearch", body=function() {
+
+			it( title="wildcard * criteria returns all documents", body=function() {
+				var path = server._getTempDir( "wildcard-star-basic" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				try {
+					collection
+						action="create"
+						collection="wildcardStarBasic"
+						path="#path#"
+						language="English";
+
+					var qry = QueryNew( 'id,title,body' );
+					var row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "1", row );
+					QuerySetCell( qry, "title", "Alpha", row );
+					QuerySetCell( qry, "body", "First document about apples", row );
+
+					row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "2", row );
+					QuerySetCell( qry, "title", "Beta", row );
+					QuerySetCell( qry, "body", "Second document about bananas", row );
+
+					index
+						collection="wildcardStarBasic"
+						action="update"
+						type="custom"
+						title="title"
+						body="body"
+						key="id"
+						query="qry"
+						urlpath="/";
+
+					search name="local.res" collection="wildcardStarBasic" criteria="*" language="English";
+					expect( res.recordcount ).toBe( 2, "wildcard * should return all documents" );
+
+					collection action="delete" collection="wildcardStarBasic";
+				}
+				finally {
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+				}
+			});
+
+			it( title="wildcard * criteria with startRow does not throw NPE", body=function() {
+				var path = server._getTempDir( "wildcard-star-startrow" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				try {
+					collection
+						action="create"
+						collection="wildcardStarPage"
+						path="#path#"
+						language="English";
+
+					var qry = QueryNew( 'id,title,body' );
+					var row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "1", row );
+					QuerySetCell( qry, "title", "Alpha", row );
+					QuerySetCell( qry, "body", "First document about cats", row );
+
+					row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "2", row );
+					QuerySetCell( qry, "title", "Beta", row );
+					QuerySetCell( qry, "body", "Second document about dogs", row );
+
+					row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "3", row );
+					QuerySetCell( qry, "title", "Gamma", row );
+					QuerySetCell( qry, "body", "Third document about birds", row );
+
+					index
+						collection="wildcardStarPage"
+						action="update"
+						type="custom"
+						title="title"
+						body="body"
+						key="id"
+						query="qry"
+						urlpath="/";
+
+					// this combination triggers NPE: criteria="*" + startRow
+					search
+						name="local.res"
+						collection="wildcardStarPage"
+						criteria="*"
+						startRow="1"
+						maxRows="2"
+						language="English";
+
+					expect( isQuery( res ) ).toBeTrue( "should return a query, not throw NPE" );
+					expect( res.recordcount ).toBeGTE( 1, "should return at least one result" );
+
+					collection action="delete" collection="wildcardStarPage";
+				}
+				finally {
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+				}
+			});
+
+			it( title="wildcard * criteria with maxRows does not throw NPE", body=function() {
+				var path = server._getTempDir( "wildcard-star-maxrows" );
+
+				if ( DirectoryExists( path ) ) {
+					directoryDelete( path, true );
+				}
+				directoryCreate( path );
+
+				try {
+					collection
+						action="create"
+						collection="wildcardStarMax"
+						path="#path#"
+						language="English";
+
+					var qry = QueryNew( 'id,title,body' );
+					var row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "1", row );
+					QuerySetCell( qry, "title", "One", row );
+					QuerySetCell( qry, "body", "Document one content", row );
+
+					row = QueryAddRow( qry );
+					QuerySetCell( qry, "id", "2", row );
+					QuerySetCell( qry, "title", "Two", row );
+					QuerySetCell( qry, "body", "Document two content", row );
+
+					index
+						collection="wildcardStarMax"
+						action="update"
+						type="custom"
+						title="title"
+						body="body"
+						key="id"
+						query="qry"
+						urlpath="/";
+
+					search
+						name="local.res"
+						collection="wildcardStarMax"
+						criteria="*"
+						maxRows="1"
+						language="English";
+
+					expect( isQuery( res ) ).toBeTrue( "should return a query, not throw NPE" );
+					expect( res.recordcount ).toBe( 1, "maxRows should limit results" );
+
+					collection action="delete" collection="wildcardStarMax";
+				}
+				finally {
+					if ( DirectoryExists( path ) ) {
+						directoryDelete( path, true );
+					}
+				}
+			});
+		});
+	}
+}


### PR DESCRIPTION
## Summary

- **LDEV-6195** — `cfindex action="delete"` was not removing individual documents. The delete code path used a hardcoded index id that no longer matched after an earlier refactor. Fixed by iterating all custom-type indexes to find the correct one.
- **LDEV-6197** — filenames were not searchable in path-type indexes. The filename was stored as metadata (`StoredField`) but never indexed. Fixed by adding filename as a `TextField` and using `MultiFieldQueryParser` to search both `contents` and `filename` fields.
- Added tests for wildcard `*` search with startRow/maxRows and purge+reindex scenarios.

## Test plan

- [x] LDEV-6195: 2 tests confirm delete removes individual docs
- [x] LDEV-6197: 2 tests confirm filename is searchable in path indexes
- [x] WildcardStarSearch: 3 tests for `criteria="*"` with pagination
- [x] PurgeAndReindex: 2 tests confirm purge+reindex has no stale data
- [x] All existing tests pass, zero regressions
- [x] CI green on Lucee 7 + 6