### PR TITLE
LDEV-6198 fix spellcheck/suggestions + minor code review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.0.169
+
+- [LDEV-6198](https://luceeserver.atlassian.net/browse/LDEV-6198) — fix spellcheck/suggestions: real Lucene string distance scores (0-100), fix `</suggestion>` tag leak in suggestedQuery, fix resource leaks (SpellChecker/FSDirectory never closed), fix NPE with `type="explicit"`, remove dead code. `suggestions="always"` now returns max 10 suggestions per term (was 1000); `suggestions="5"` returns up to 5.
+
 ## 3.0.0.168
 
 - [LDEV-6196](https://luceeserver.atlassian.net/browse/LDEV-6196) — fix `cfsearch` context highlighting markers not reaching extension (requires Lucee Loader 7.0.3.30+)

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.lucee</groupId>
     <artifactId>lucene-search-extension</artifactId>
-    <version>3.0.0.168-SNAPSHOT</version>
+    <version>3.0.0.169-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Lucene Search Engine</name>
 

--- a/source/java/src/org/lucee/extension/search/SearchCollectionSupport.java
+++ b/source/java/src/org/lucee/extension/search/SearchCollectionSupport.java
@@ -373,7 +373,7 @@ public abstract class SearchCollectionSupport implements SearchCollection {
 	public final IndexResult indexCustom(String id, QueryColumn title, QueryColumn keyColumn, QueryColumn[] bodyColumns,
 			String language, QueryColumn urlPath, QueryColumn custom1, QueryColumn custom2, QueryColumn custom3,
 			QueryColumn custom4) throws SearchException {
-		IndexResult ir = _indexCustom(id, title, keyColumn, bodyColumns, language, null, custom1, custom2, custom3,
+		IndexResult ir = _indexCustom(id, title, keyColumn, bodyColumns, language, urlPath, custom1, custom2, custom3,
 				custom4);
 		changeLastUpdate();
 		return ir;

--- a/source/java/src/org/lucee/extension/search/SearchEngineSupport.java
+++ b/source/java/src/org/lucee/extension/search/SearchEngineSupport.java
@@ -171,7 +171,7 @@ public abstract class SearchEngineSupport implements SearchEngine {
 		String[] cols = new String[] { "external", "language", "mapped", "name", "online", "path", "registered",
 				"lastmodified", "categories", "charset", "created", "size", "doccount", "mode", "embedding", "ratio" };
 		String[] types = new String[] { "BOOLEAN", v, "BOOLEAN", v, "BOOLEAN", v, v, "DATE", "BOOLEAN", v, "OBJECT",
-				"DOUBLE", "DOUBLE", v };
+				"DOUBLE", "DOUBLE", v, v, "DOUBLE" };
 		try {
 			query = engine.getCreationUtil().createQuery(cols, types, collections.size(), "query");
 		} catch (PageException e) {

--- a/source/java/src/org/lucee/extension/search/SuggestionItemImpl.java
+++ b/source/java/src/org/lucee/extension/search/SuggestionItemImpl.java
@@ -9,23 +9,22 @@ public class SuggestionItemImpl implements SuggestionItem {
 
 	final Array keywords;
 	final Array keywordsScore;
-	
-	public SuggestionItemImpl(String[] arr) {
+
+	public SuggestionItemImpl(String[] arr, double[] scores) {
 		Creation c = CFMLEngineFactory.getInstance().getCreationUtil();
 		keywords=c.createArray();
 		keywordsScore=c.createArray();
-		
-		
-		add(arr);
+
+		add(arr, scores);
 	}
 
-	public void add(String[] arr) {
+	public void add(String[] arr, double[] scores) {
 		for(int i=0;i<arr.length;i++) {
 			keywords.appendEL(arr[i]);
-			keywordsScore.appendEL(Double.valueOf(99-i));
+			keywordsScore.appendEL(Double.valueOf(Math.round(scores[i] * 100)));
 		}
 	}
-	
+
 	@Override
 	public Array getKeywords() {
 		return keywords;

--- a/source/java/src/org/lucee/extension/search/lucene/LuceneSearchCollection.java
+++ b/source/java/src/org/lucee/extension/search/lucene/LuceneSearchCollection.java
@@ -885,11 +885,10 @@ public final class LuceneSearchCollection extends SearchCollectionSupport {
 			// remove start rows
 			if (startrow > 1) {
 				int start = startrow;
-				while (start > 1) {
+				while (start > 1 && !list.isEmpty()) {
 					list.remove(0);
 					start--;
 				}
-				// list.remove(start)
 			}
 
 			// remove max rows
@@ -904,7 +903,6 @@ public final class LuceneSearchCollection extends SearchCollectionSupport {
 			throw CommonUtil.toSearchException(e);
 		}
 	}
-
 
 	private boolean removeCorrupt(Resource dir) {
 		if (engine.getResourceUtil().isEmptyFile(dir)) {
@@ -1119,7 +1117,9 @@ public final class LuceneSearchCollection extends SearchCollectionSupport {
 		// return true;
 		// if(StringUtil.isEmpty(categoryTreeSearch) || categoryTreeSearch.equals("/"))
 		// return true;
-		return categoryTreeIndex.startsWith(categoryTreeSearch);
+		return categoryTreeIndex.equals(categoryTreeSearch)
+				|| categoryTreeIndex.startsWith(categoryTreeSearch + "/")
+				|| "/".equals(categoryTreeSearch);
 	}
 
 	/**
@@ -1346,7 +1346,9 @@ public final class LuceneSearchCollection extends SearchCollectionSupport {
 			try {
 				writers[i] = _getWriter(files[i].getName(), create);
 			} catch (IOException e) {
+				error(e);
 			} catch (PageException e) {
+				error(new SearchException(e.getMessage()));
 			}
 		}
 		return writers;

--- a/source/java/src/org/lucee/extension/search/lucene/LuceneSearchCollection.java
+++ b/source/java/src/org/lucee/extension/search/lucene/LuceneSearchCollection.java
@@ -275,41 +275,18 @@ public final class LuceneSearchCollection extends SearchCollectionSupport {
 		}
 	}
 
-	private void indexSpellCheckOld(String id) throws SearchException {
-		if (!spellcheck)
-			return;
-
-		IndexReader reader = null;
-		FSDirectory spellDir = null;
-
-		Resource dir = _createSpellDirectory(id);
-		try {
-			Path spellPath = engine.getCastUtil().toFile(dir).toPath();
-			spellDir = FSDirectory.open(spellPath);
-			reader = _getReader(id, false);
-			Dictionary dictionary = new LuceneDictionary(reader, "contents");
-
-			SpellChecker spellChecker = new SpellChecker(spellDir);
-			spellChecker.indexDictionary(dictionary, _getConfig(), true);
-
-		} catch (Exception e) {
-			throw CommonUtil.toSearchException(e);
-		} finally {
-			closeEL(reader);
-		}
-	}
-
 	private void indexSpellCheck(String id) throws SearchException {
 		if (!spellcheck)
 			return;
 
 		IndexReader reader = null;
 		FSDirectory spellDir = null;
+		SpellChecker spellChecker = null;
 
 		Resource dir = _createSpellDirectory(id);
 		try {
 			spellDir = FSDirectory.open(engine.getCastUtil().toFile(dir).toPath());
-			SpellChecker spellChecker = new SpellChecker(spellDir);
+			spellChecker = new SpellChecker(spellDir);
 
 			reader = _getReader(id, false);
 			Dictionary dictionary = new LuceneDictionary(reader, "contents");
@@ -319,9 +296,10 @@ public final class LuceneSearchCollection extends SearchCollectionSupport {
 		} catch (Exception e) {
 			throw CommonUtil.toSearchException(e);
 		} finally {
+			if (spellChecker != null) try { spellChecker.close(); } catch (Exception e) {}
+			if (spellDir != null) try { spellDir.close(); } catch (Exception e) {}
 			closeEL(reader);
 		}
-
 	}
 
 	private void close(IndexWriter writer) throws SearchException {
@@ -848,8 +826,9 @@ public final class LuceneSearchCollection extends SearchCollectionSupport {
 				}
 			}
 
-			// spellcheck
-			if (spellcheck && data != null && data.getSuggestionMax() >= list.size()) {
+			// spellcheck — skip when type=explicit (no Verity parser terms to check)
+			if (spellcheck && data != null && data.getSuggestionMax() >= list.size()
+					&& type != SEARCH_TYPE_EXPLICIT) {
 				Map<String, SuggestionItem> suggestions = data.getSuggestion();
 				Iterator<String> it = spellCheckIndex.iterator();
 				String id;
@@ -860,19 +839,37 @@ public final class LuceneSearchCollection extends SearchCollectionSupport {
 				while (it.hasNext()) {
 					id = it.next();
 					SuggestionItemImpl si;
-					SpellChecker sc = getSpellChecker(id);
+					SpellChecker sc = null;
+					FSDirectory siDir = null;
+					try {
+						siDir = FSDirectory.open(engine.getCastUtil().toFile(_getSpellDirectory(id)).toPath());
+						sc = new SpellChecker(siDir);
 
-					for (int i = 0; i < strLiterals.length; i++) {
-						String[] arr = sc.suggestSimilar(strLiterals[i], 1000);
-						if (arr.length > 0) {
-							literals[i].set("<suggestion>" + arr[0] + "</suggestion>");
-							setSuggestionQuery = true;
-							si = (SuggestionItemImpl) suggestions.get(strLiterals[i]);
-							if (si == null)
-								suggestions.put(strLiterals[i], new SuggestionItemImpl(arr));
-							else
-								si.add(arr);
+						for (int i = 0; i < strLiterals.length; i++) {
+							int maxSuggestions = Math.min(data.getSuggestionMax(), 10);
+							String[] arr = sc.suggestSimilar(strLiterals[i], maxSuggestions);
+							if (arr.length > 0) {
+								literals[i].setSuggestion(arr[0]);
+								setSuggestionQuery = true;
+
+								// compute real Lucene string distance scores
+								double[] scores = new double[arr.length];
+								for (int j = 0; j < arr.length; j++) {
+									scores[j] = sc.getStringDistance().getDistance(strLiterals[i], arr[j]);
+								}
+
+								si = (SuggestionItemImpl) suggestions.get(strLiterals[i]);
+								if (si == null)
+									suggestions.put(strLiterals[i], new SuggestionItemImpl(arr, scores));
+								else
+									si.add(arr, scores);
+							}
 						}
+					} catch (Exception e) {
+						error(e);
+					} finally {
+						if (sc != null) try { sc.close(); } catch (Exception e) {}
+						if (siDir != null) try { siDir.close(); } catch (Exception e) {}
 					}
 				}
 				if (setSuggestionQuery) {
@@ -908,11 +905,6 @@ public final class LuceneSearchCollection extends SearchCollectionSupport {
 		}
 	}
 
-	private SpellChecker getSpellChecker(String id) throws IOException, PageException {
-		FSDirectory siDir = FSDirectory.open(engine.getCastUtil().toFile(_getSpellDirectory(id)).toPath());
-		SpellChecker spellChecker = new SpellChecker(siDir);
-		return spellChecker;
-	}
 
 	private boolean removeCorrupt(Resource dir) {
 		if (engine.getResourceUtil().isEmptyFile(dir)) {
@@ -1530,7 +1522,6 @@ public final class LuceneSearchCollection extends SearchCollectionSupport {
 	}
 
 	private void error(Exception e) {
-		e.printStackTrace();
 		if (log == null) {
 			e.printStackTrace();
 			return;

--- a/source/java/src/org/lucee/extension/search/lucene/query/Literal.java
+++ b/source/java/src/org/lucee/extension/search/lucene/query/Literal.java
@@ -10,6 +10,7 @@ public final class Literal implements Op {
 	String literal;
 	String modifier = "";
 	boolean quoted = false;
+	boolean hasSuggestion = false;
 
 	public Literal(String literal) {
 		this.literal=literal;
@@ -24,11 +25,14 @@ public final class Literal implements Op {
 	public String toString() {
 		if (quoted)
 			return modifier + "\"" + literal + "\"";
+		if (hasSuggestion)
+			return modifier + literal;
 		return modifier + escapeLuceneSpecialChars(literal);
 	}
 
-	public void set(String literal) {
-		this.literal=literal;
+	public void setSuggestion(String suggestion) {
+		this.literal = "<suggestion>" + suggestion + "</suggestion>";
+		this.hasSuggestion = true;
 	}
 
 	public void setModifier(String modifier) {

--- a/tests/LDEV6198.cfc
+++ b/tests/LDEV6198.cfc
@@ -1,0 +1,183 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="search" {
+
+	function beforeAll() {
+		variables.colName = "spellcheckTest";
+		variables.path = server._getTempDir( "spellcheck-test" );
+
+		if ( DirectoryExists( variables.path ) ) {
+			directoryDelete( variables.path, true );
+		}
+		directoryCreate( variables.path );
+
+		collection
+			action="create"
+			collection="#variables.colName#"
+			path="#variables.path#"
+			language="English";
+
+		// rich vocabulary so the spellchecker dictionary has enough words to
+		// suggest multiple alternatives for misspellings
+		var qry = QueryNew( 'id,title,body' );
+
+		var row = QueryAddRow( qry );
+		QuerySetCell( qry, "id", "1", row );
+		QuerySetCell( qry, "title", "Search Engine Architecture", row );
+		QuerySetCell( qry, "body", "A search engine consists of a crawler, an indexer, and a query processor. The indexer builds an inverted index from crawled documents. Search engines use complex algorithms to rank results by relevance.", row );
+
+		row = QueryAddRow( qry );
+		QuerySetCell( qry, "id", "2", row );
+		QuerySetCell( qry, "title", "Performance and Optimization", row );
+		QuerySetCell( qry, "body", "Performance of search applications depends on index structure. Permanent storage solutions and caching improve throughput. Permission controls ensure secure access to indexed content. Personal preferences can customize ranking.", row );
+
+		row = QueryAddRow( qry );
+		QuerySetCell( qry, "id", "3", row );
+		QuerySetCell( qry, "title", "Indexing Documents", row );
+		QuerySetCell( qry, "body", "Document indexing processes text through analysis, tokenization, and normalization. The analyzer handles stemming and stop word removal. Indexed documents are stored in segments that are periodically merged.", row );
+
+		row = QueryAddRow( qry );
+		QuerySetCell( qry, "id", "4", row );
+		QuerySetCell( qry, "title", "Query Processing", row );
+		QuerySetCell( qry, "body", "Query processing involves parsing user input into structured queries. Boolean operators combine terms with AND, OR, and NOT logic. Phrase queries match exact sequences of words in the index.", row );
+
+		row = QueryAddRow( qry );
+		QuerySetCell( qry, "id", "5", row );
+		QuerySetCell( qry, "title", "Relevance Scoring", row );
+		QuerySetCell( qry, "body", "Relevance scoring uses term frequency and inverse document frequency. Important terms that appear rarely across documents score higher. Persistent caching of scoring data improves repeated query performance.", row );
+
+		index
+			collection="#variables.colName#"
+			action="update"
+			type="custom"
+			title="title"
+			body="body"
+			key="id"
+			query="qry"
+			urlpath="/";
+	}
+
+	function afterAll() {
+		try { collection action="delete" collection="#variables.colName#"; } catch( any e ) {}
+		if ( DirectoryExists( variables.path ) ) {
+			directoryDelete( variables.path, true );
+		}
+	}
+
+	function run( testResults, testBox ) {
+		describe( title="LDEV-6198: cfsearch suggestions/spellcheck", body=function() {
+
+			it( title="suggestedQuery returned with clean tags for misspelled term", body=function() {
+				search
+					name="local.res"
+					collection="#variables.colName#"
+					criteria="serch"
+					language="English"
+					suggestions="always"
+					status="local.stats";
+
+				systemOutput( "test1 stats: " & serializeJSON( stats ), true );
+
+				expect( stats ).toHaveKey( "suggestedQuery" );
+				expect( len( stats.suggestedQuery ) ).toBeGT( 0, "suggestedQuery should not be empty" );
+				// tags should be fully stripped by Lucee core — no leftover <suggestion> or </suggestion>
+				expect( stats.suggestedQuery ).notToInclude( "<suggestion>", "open tag should be stripped" );
+				expect( stats.suggestedQuery ).notToInclude( "</suggestion>", "close tag should be stripped" );
+				expect( stats.suggestedQuery ).notToInclude( "<\/suggestion>", "escaped close tag should not appear" );
+				expect( stats.suggestedQuery ).toInclude( "search", "should correct 'serch' to 'search'" );
+			});
+
+			it( title="keywords struct populated for misspelled term", body=function() {
+				search
+					name="local.res"
+					collection="#variables.colName#"
+					criteria="serch"
+					language="English"
+					suggestions="always"
+					status="local.stats";
+
+				expect( stats ).toHaveKey( "keywords" );
+				expect( isStruct( stats.keywords ) ).toBeTrue( "keywords should be a struct" );
+				expect( structCount( stats.keywords ) ).toBeGT( 0, "should have keyword suggestions" );
+			});
+
+			it( title="multiple suggestions with real scores for ambiguous misspelling", body=function() {
+				// "perman" is close to "permanent", "performance", "personal", "permission"
+				// — should produce multiple suggestions with varying Lucene string distances
+				search
+					name="local.res"
+					collection="#variables.colName#"
+					criteria="perman"
+					language="English"
+					suggestions="always"
+					status="local.stats";
+
+				systemOutput( "test3 stats: " & serializeJSON( stats ), true );
+
+				expect( stats ).toHaveKey( "keywordScore" );
+				expect( isStruct( stats.keywordScore ) ).toBeTrue();
+				expect( structCount( stats.keywordScore ) ).toBeGT( 0 );
+
+				for ( var term in stats.keywordScore ) {
+					var scoreArr = stats.keywordScore[ term ];
+					expect( isArray( scoreArr ) ).toBeTrue();
+					expect( arrayLen( scoreArr ) ).toBeGT( 0 );
+
+					for ( var s in scoreArr ) {
+						expect( s ).toBeGTE( 0, "score should be >= 0" );
+						expect( s ).toBeLTE( 100, "score should be <= 100" );
+					}
+
+					// if we have 2+ suggestions, verify scores aren't a simple countdown
+					if ( arrayLen( scoreArr ) >= 2 ) {
+						var allGapsAreOne = true;
+						for ( var i = 2; i <= arrayLen( scoreArr ); i++ ) {
+							if ( scoreArr[ i - 1 ] - scoreArr[ i ] != 1 ) {
+								allGapsAreOne = false;
+								break;
+							}
+						}
+						expect( allGapsAreOne ).toBeFalse( "scores should be real Lucene distances, not a fake 99,98,97 countdown" );
+					}
+				}
+			});
+
+			it( title="suggestions=never returns no suggestions", body=function() {
+				search
+					name="local.res"
+					collection="#variables.colName#"
+					criteria="serch"
+					language="English"
+					suggestions="never"
+					status="local.stats";
+
+				var hasKeywords = structKeyExists( stats, "keywords" ) && isStruct( stats.keywords ) && structCount( stats.keywords ) > 0;
+				expect( hasKeywords ).toBeFalse( "should have no suggestions when suggestions=never" );
+			});
+
+			it( title="correct spelling produces no false corrections", body=function() {
+				search
+					name="local.res"
+					collection="#variables.colName#"
+					criteria="search"
+					language="English"
+					suggestions="always"
+					status="local.stats";
+
+				expect( res.recordcount ).toBeGT( 0, "correctly spelled term should find results" );
+			});
+
+			it( title="type=explicit with suggestions does not NPE", body=function() {
+				search
+					name="local.res"
+					collection="#variables.colName#"
+					criteria="serch"
+					language="English"
+					type="explicit"
+					suggestions="always"
+					status="local.stats";
+
+				// should not throw — that's the main assertion
+				expect( isStruct( stats ) ).toBeTrue();
+			});
+		});
+	}
+}

--- a/tests/SearchFeatures.cfc
+++ b/tests/SearchFeatures.cfc
@@ -85,6 +85,12 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="search" {
 				expect( isQuery( res ) ).toBeTrue( "should still return a query object" );
 			});
 
+			it( title="startRow past end of results returns empty", body=function() {
+				search name="local.res" collection="searchFeatA" criteria="fox" language="English"
+					startRow=999 maxRows=10;
+				expect( res.recordcount ).toBe( 0, "startRow past results should return empty, not crash" );
+			});
+
 			it( title="context highlight markers", body=function() {
 				search
 					name="local.res"


### PR DESCRIPTION
## Summary

- **LDEV-6198** — fix spellcheck/suggestions subsystem: real Lucene string distance scores (0-100) instead of fake countdown, fix `</suggestion>` tag leak in suggestedQuery, close SpellChecker/FSDirectory resources, fix NPE with `type="explicit"`, cap suggestions at 10 for `always` (was 1000), remove dead code
- Fix `startRow` past end of results causing `IndexOutOfBoundsException`
- Fix `matchCategoryTree` prefix matching `/foo` against `/foobar`
- Log errors in `_getWriters` instead of silently swallowing them
- Fix `indexCustom` silently dropping `urlPath` parameter
- Fix `getCollectionsAsQuery` types array missing entries for mode, embedding, ratio columns

## Test plan

- [x] `LDEV6198.cfc` — misspelled suggestions, real scores, clean tags, `suggestions="never"`, `type="explicit"` NPE
- [x] `SearchFeatures.cfc` — startRow past end returns empty (not crash)
- [x] All existing tests pass on Lucee 7 + 6 (107 + 103)
- [x] CI green